### PR TITLE
Minor: change print to Python 3

### DIFF
--- a/docs/functions/attributes/basics.md
+++ b/docs/functions/attributes/basics.md
@@ -32,6 +32,6 @@ We need to set `data=True` to access the attributes.
 
 ```python
 for n1, n2 in list(G.edges(data=True)):
-    print G.node[n1]['name'], G.node[n2]['name']
-    print G.node[n1]['year_of_birth'], G.node[n2]['year_of_birth']
+    print(G.node[n1]['name'], G.node[n2]['name'])
+    print(G.node[n1]['year_of_birth'], G.node[n2]['year_of_birth'])
 ```


### PR DESCRIPTION
There was a code snippet using the Python 2 print syntax. This PR updates it to the Python 3 print syntax.